### PR TITLE
cytoscape/cytoscape#35: Make 'mvn clean install' work from the root of a fresh clone

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -32,7 +32,7 @@
             <enabled>false</enabled>
           </releases>
           <name>Cytoscape Snapshots</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
         </repository>
         <repository>
           <id>cytoscape_releases</id>
@@ -43,7 +43,7 @@
             <enabled>true</enabled>
           </releases>
           <name>Cytoscape Releases</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
         </repository>
         <repository>
           <id>cytoscape_thirdparty</id>
@@ -54,12 +54,12 @@
             <enabled>true</enabled>
           </releases>
           <name>Cytoscape Third Party</name>
-          <url>http://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
+          <url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_thirdparty/</url>
         </repository>
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ cd cytoscape
 ```
 [Eclipse Users](https://github.com/cytoscape/cytoscape/wiki/Importing-Git-Repos-in-Eclipse) - Eclipse Import Instructions
 
-*NOTE: Build order matters, and ```./cy.sh build``` takes care of it for you — it builds api/event-api, then api, then support, then impl, and only then the whole project. This is not optional: api/pom.xml and impl/pom.xml bind maven-source-plugin's ```aggregate``` goal, which forks a separate build that resolves dependencies from your local maven repository instead of from the reactor. On a first build nothing is in that repository yet, so a plain ```mvn install``` from the top dies at the second of 122 modules looking for event-api. Building the inner pieces first puts them in the repository so those forked builds can find them.*
+*NOTE: A plain ```mvn clean install -DskipTests``` from the top now works, including on a first build with an empty local maven repository. ```./cy.sh build``` still works and is still the easy path, but it is no longer required. This was not always true: api/pom.xml and impl/pom.xml used to bind maven-source-plugin's ```aggregate``` goal in the default build, and that goal forks a separate build which resolves dependencies from your local maven repository instead of from the reactor — so a first build died at the second of 122 modules looking for event-api, and the inner projects had to be built first to seed the repository. That execution now lives in a ```sources``` profile; see [Building the app-developer distribution](#building-the-app-developer-distribution).*
 
 *ANOTHER NOTE: Test compilation cannot be skipped — 34 of the poms depend on another module's test-jar. Use ```-DskipTests``` (compiles tests, does not run them), never ```-Dmaven.test.skip=true``` (does not compile them at all, so the test-jars are never produced and everything needing one fails). ```./cy.sh build``` already does this.*
 
-*ANOTHER NOTE: If you see errors about "Could not transfer artifact" and "Blocked mirror for repositories," then you may be running a newer version of Maven that doesn't work for our repo at this time. Try Maven v3.6.0*
+*ANOTHER NOTE: Errors about "Could not transfer artifact" and "Blocked mirror for repositories" mean Maven has refused a plain-```http://``` repository, which it has done by default since 3.8.1. Every repository in this tree is now ```https://```, so a current Maven is the right choice — 3.9.x is what these instructions are verified against. Do not downgrade to Maven 3.6.0 to work around it. If you still hit this, check for stale ```http://``` repository URLs in your own ```~/.m2/settings.xml```.*
 
 ### cy.sh commands
 Cytoscape core is spread over seven repositories, and the core apps over twenty more. The _cy_ script drives all of them together, so you rarely run _git_ or _maven_ in a single repository by hand. Every command below is run from inside your clone of this repository and acts on **all** of the repositories in its column:
@@ -271,9 +271,11 @@ Build from whichever branch you end up on — the steps below are the same eithe
 1. Run: ```./cy.sh build```
 1. Have a coffee break...  It depends on your machine specification and internet connection speed, but will take 3-60 minutes.  When you build Cytoscape for the first time, it will take a long time because maven downloads all dependencies from the remote server.
 
-Use ```./cy.sh build``` rather than calling Maven yourself. A plain ```mvn install``` from the top **fails on a first build** — see the note about build order above — whereas ```cy.sh build``` runs the sub-builds in the order that works and passes the right flags. It is safe to re-run at any time; it works the same on a fresh clone and on an up-to-date one.
+```./cy.sh build``` is the easy path — it passes the right flags and is safe to re-run at any time, working the same on a fresh clone and on an up-to-date one.
 
-If you do want to drive Maven directly, the equivalent of the final step is ```mvn -fae install -U -DskipTests```, but it only works once ```api```, ```support``` and ```impl``` have already been installed.
+Driving Maven yourself also works now, from the top, on a first build: ```mvn clean install -DskipTests```. (Before [#35](https://github.com/cytoscape/cytoscape/issues/35) this failed unless ```api```, ```support``` and ```impl``` had already been installed.)
+
+If you want the app-developer sources JARs as well, see [Building the app-developer distribution](#building-the-app-developer-distribution) — that needs a second Maven pass.
 
 ### Step 4: Run the new build
 Now you are ready to run the new
@@ -291,6 +293,18 @@ Note that if you want to test the new build with a clean slate, we recommend to 
 ### Step 5: Continue with Eclipse project steps
 If you are developing in Eclipse, continue to set up with [these steps](https://github.com/cytoscape/cytoscape/wiki/Importing-Git-Repos-in-Eclipse).
 You can also configure Eclipse to [debug Cytoscape](https://github.com/cytoscape/cytoscape/wiki/Launching-Cytoscape-from-Eclipse).
+
+### Building the app-developer distribution
+The app-developer kit ships two aggregated sources JARs — ```api-<version>-sources.jar``` and ```impl-<version>-sources.jar``` — so that app authors can attach the Cytoscape sources in their IDE while debugging. Those two JARs are built by the ```sources``` profile, which is **not** part of the default build, so producing a complete kit takes two Maven passes:
+
+```sh
+mvn clean install -DskipTests
+mvn install -Psources -DskipTests
+```
+
+The second command has to be a **separate** invocation — you cannot simply add ```-Psources``` to the first one. The profile turns on maven-source-plugin's ```aggregate``` goal, which forks a build of every module and resolves those modules from your local maven repository rather than from the reactor. On a cold repository it would therefore look for artifacts that have not been built yet and fail, which is exactly the problem described in [#35](https://github.com/cytoscape/cytoscape/issues/35). The first pass installs everything, so the second pass resolves cleanly — and it is quick, because every module is already up to date.
+
+You only need this when you are producing the app-developer kit. A normal development build does not use those JARs: skip the second pass and the distribution still builds, just without them.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -593,11 +593,14 @@ Though this will update most instances of the version number, it doesn't get the
 * parent/pom.xml (look for taglets)
 * pom.xml in app-developer, gui-distribution, impl, support (look for properties tag)
 * pom.xml in src/main/resources/archetype-resources/pom.xml (for each archetype subdirectory in support/archetypes)
+* **support/archetypes/cytoscape-starter-app/src/main/resources/archetype-resources/pom.xml — check the ```<cytoscape.version>``` property specifically.** Four of the five archetypes repeat the version literally in each dependency, so a search for the outgoing version finds them. This one indirects through a property that feeds eight dependency versions, and the property can be left holding a version unrelated to the one you are replacing — so searching for the outgoing version will not find it. It sat at 3.8.0 for several releases before anyone noticed, which meant every app generated from that archetype built against 3.8.0 (cytoscape/cytoscape#35).
 * pom.xml in event-impl/it, model-impl/it, model-impl/performance, session-impl/impl, session-impl/integration-test, viewmodel-impl/it, vizmap-impl/it, work-swing-impl/it
 
 You can edit by hand, or use grep/sed to update these numbers.  Push and commit all changes to GitHub when you are done updating the version numbers.
 
 #### Tip: To find all instances of a version, run ```grep -ri "3.X.X-SNAPSHOT" .``` from the parent directory.
+
+#### Tip: That search only finds the version you are replacing. To catch places already holding some other stale version, also run ```grep -rn "<cytoscape.version>" .``` and check each hit by eye.
 
 ## Releasing unreleased updates to core apps
 Typically, updates to core apps will be released separately from the Cytoscape core development cycle, and the development branch will be updated to use any new updates as they are released. However, if a core app depends on an unreleased API in the development version of Cytoscape, this won't work. In that case, we have to release the unreleased core app when Cytoscape is being released.


### PR DESCRIPTION
Fixes the two problems that stop `mvn clean install` working from the root of a fresh clone, described in #35.

This is a coordinated change across seven repositories. **The `api`, `impl` and `app-developer` PRs must merge together** — see "Merge order" below.

## Related PRs

| Repository | PR | Contains |
| --- | --- | --- |
| cytoscape (this one) | #36 | HTTPS repos, README |
| cytoscape-api | cytoscape/cytoscape-api#15 | `sources` profile, HTTPS repos |
| cytoscape-impl | cytoscape/cytoscape-impl#52 | `sources` profile, HTTPS repos, drop SpringSource |
| cytoscape-gui-distribution | cytoscape/cytoscape-gui-distribution#12 | HTTPS repos, drop EBI `psidev` |
| cytoscape-app-developer | cytoscape/cytoscape-app-template#1 | `sources` profile, HTTPS repos |
| cytoscape-parent | — | HTTPS repos (already merged) |
| cytoscape-support | — | HTTPS repos (already merged) |

(The app-developer PR shows under `cytoscape-app-template`; that repository has been renamed and the old name redirects.)

## 1. `source:aggregate` forked the reactor too early

`api/pom.xml` and `impl/pom.xml` bound maven-source-plugin's `aggregate` goal to the `package` phase of their aggregator POM. That goal forks a `generate-sources` lifecycle over every module, and a forked lifecycle resolves dependencies from the local repository instead of the reactor. Running at `api-parent` — module 2 of 122 — it looked for `event-api` before the reactor had built it, so a build died there whenever the current version was not already in `~/.m2`, which is every build right after a version bump. `impl-parent` had the same problem at module 33.

This is not a circular dependency: the module graph is acyclic and Maven's reactor order was already correct.

Both executions move into a `sources` profile. The aggregated JARs are still needed by the app-developer kit, which is now a two-pass build:

```sh
mvn clean install -DskipTests
mvn install -Psources -DskipTests
```

The second pass has to be separate — adding `-Psources` to a single cold build recreates the original failure. `app-developer` gains a matching `sources` profile so both halves activate together.

Note `-Dmaven.source.skip=true` does *not* avoid the fork; it is planned before the skip flag is evaluated.

## 2. Plain-HTTP repositories are blocked

Maven 3.8.1+ refuses plain-`http://` repositories. Every remaining `http://` nrnb-nexus URL, and the `http://` Maven Central URL in the Travis settings, is switched to `https://`. Repository ids are unchanged, so cached artifacts stay valid.

Two dead repositories are removed:

- **SpringSource** (`impl/table-import-impl`) — `repository.springsource.com` no longer resolves over http or https.
- **EBI `psidev`** (`gui-distribution/third-party`) — this one was subtle. Two different POMs exist for `psidev.psi.mi:psi25-xml:1.8.6`: `cytoscape_thirdparty` serves a 360-byte stripped POM with no parent and no dependencies, while EBI serves the real 8448-byte POM whose parent `psimi-master` declares a list of long-dead plain-http repos (intact.nexus, ebi-repo, springsource, codehaus, download.java.net, pride-proteomics) and pulls in `cpdetector` and the SpringSource commons-logging/log4j bundles. Declaring `psidev` put it ahead of `cytoscape_thirdparty` in resolution order, so any machine without the stripped POM already cached fetched the real one and failed. A developer machine with a warm `~/.m2` never sees this.

## Documentation

The README gains a **Building the app-developer distribution** section, and three statements this change makes false are corrected: that the fixed build order is "not optional", that a plain `mvn install` fails on a first build, and the advice to downgrade to Maven 3.6.0 when you see "Blocked mirror for repositories".

## Verification

Maven 3.9.14 / Java 25, on `develop`, against a **genuinely empty** local repository (`-Dmaven.repo.local` pointed at an empty directory, 1.7 GB downloaded) with no `-s` settings file, so the http blocker was fully active:

| | Result |
|---|---|
| `mvn clean install -DskipTests` | 122 SUCCESS / 0 FAILURE / 0 SKIPPED |
| `mvn install -Psources -DskipTests` | 122 SUCCESS / 0 FAILURE / 0 SKIPPED |

Zero blocked-mirror errors. `app-developer/target/lib/` ends up with the same three files as before the change.

## Merge order

- `cytoscape-parent` and `cytoscape-support` contained only the HTTPS change and are **already merged** to `develop`.
- cytoscape/cytoscape-api#15, cytoscape/cytoscape-impl#52 and cytoscape/cytoscape-app-template#1 carry the `sources` profile change and **must merge together**. Merging `app-developer` alone would move the sources JARs behind a profile while `api`/`impl` still produce them by default, so the kit would silently stop shipping them.
- cytoscape/cytoscape-gui-distribution#12 and this repo are independent and can merge in any order.

## Not included

- `release/3.10.5` is untouched. Merging this branch there would drag in unrelated develop history including the 3.11.0-SNAPSHOT version bump, and these commits were authored against `develop`, where `parent/pom.xml` is already HTTPS — that branch has more http URLs and needs its own fix.
- `cy.sh`'s `build` function still runs the five-stage sequence and its comment still describes the fork as a live constraint. Still works, now redundant.
- `impl/.mvn/settings.xml` still neutralises Maven's http blocker for builds run from `impl/` (added for the CI workflow in #27). Likely redundant now, left for that work to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions to support a fresh-repository Maven build.
  * Clarified Maven 3.9.x and HTTPS repository requirements.
  * Documented the additional step for generating app-developer source JARs.
  * Added guidance for verifying release versions and identifying stale version properties.
* **Chores**
  * Updated repository connections to use secure HTTPS URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
